### PR TITLE
Fix TF2 deployment compatibility and improve startup validation

### DIFF
--- a/chineseChatbotWeb-tf2.0/seq2seqChatbot/data_util.py
+++ b/chineseChatbotWeb-tf2.0/seq2seqChatbot/data_util.py
@@ -15,8 +15,9 @@ gConfig=getConfig.get_config()
 conv_path = gConfig['resource_data']
  
 if not os.path.exists(conv_path):
-	
-	exit()
+	raise FileNotFoundError(f"未找到训练语料文件: {conv_path}")
+if os.path.getsize(conv_path) == 0:
+	raise ValueError(f"训练语料文件为空: {conv_path}")
 #下面这段我们需要完成一件事，就是将训练集的数据识别读取并存入一个List中，大概分为以下几个步骤
 #a、打开文件 
 #b、读取文件中的内容，并对文件的数据进行初步处理
@@ -66,6 +67,6 @@ for i in range(len(seq)):
       print(len(range(len(seq))), '处理进度：', i)
  
 seq_train.close()
-
+print("数据预处理完成，输出文件：%s，样本数：%d" % (gConfig['seq_data'], len(seq)))
 
 

--- a/chineseChatbotWeb-tf2.0/seq2seqChatbot/execute.py
+++ b/chineseChatbotWeb-tf2.0/seq2seqChatbot/execute.py
@@ -24,8 +24,22 @@ def preprocess_sentence(w):
     return w
 
 def create_dataset(path, num_examples):
-    lines = io.open(path, encoding='UTF-8').read().strip().split('\n')
-    word_pairs = [[preprocess_sentence(w)for w in l.split('\t')] for l in lines[:num_examples]]
+    raw_text = io.open(path, encoding='UTF-8').read().strip()
+    if not raw_text:
+        raise ValueError(
+            "训练数据为空，请先准备 train_data/xiaohuangji50w_nofenci.conv 后再运行 data_util.py。"
+        )
+
+    lines = raw_text.split('\n')
+    word_pairs = []
+    for line in lines[:num_examples]:
+        parts = line.split('\t')
+        if len(parts) != 2:
+            continue
+        word_pairs.append([preprocess_sentence(w) for w in parts])
+
+    if not word_pairs:
+        raise ValueError("未解析到可用的问答对，请检查 seq.data 是否为“问题\\t回答”格式。")
 
     return zip(*word_pairs)
 

--- a/chineseChatbotWeb-tf2.0/seq2seqChatbot/getConfig.py
+++ b/chineseChatbotWeb-tf2.0/seq2seqChatbot/getConfig.py
@@ -1,8 +1,8 @@
+from configparser import ConfigParser
 
-from configparser import SafeConfigParser
 
-def get_config(config_file='seq2seqChatbot.ini'):
-    parser = SafeConfigParser()
+def get_config(config_file='seq2seq.ini'):
+    parser = ConfigParser()
     parser.read(config_file)
     # get the ints, floats and strings
     _conf_ints = [ (key, int(value)) for key,value in parser.items('ints') ]

--- a/chineseChatbotWeb-tf2.0/seq2seqChatbot/requirements.txt
+++ b/chineseChatbotWeb-tf2.0/seq2seqChatbot/requirements.txt
@@ -1,0 +1,4 @@
+tensorflow>=2.16
+flask>=0.11.1
+jieba>=0.42
+zhon>=2.1


### PR DESCRIPTION
### Motivation
- Modern Python/TensorFlow environments fail to load the TF2.0 demo due to deprecated config parsing and lack of clear data-validation, so startup crashes obscure the real problem.
- Provide clearer early-failure messages and an easy way to install runtime dependencies so users can follow the README deployment flow reliably.

### Description
- Replace deprecated `SafeConfigParser` with `ConfigParser` and set the default config file to `seq2seq.ini` in `seq2seqChatbot/getConfig.py` so configuration loads on modern Python versions.
- Add explicit checks for the presence and non-emptiness of the source corpus in `seq2seqChatbot/data_util.py` and raise clear errors when missing or empty.
- Improve dataset parsing in `seq2seqChatbot/execute.py` by validating `seq.data` content, skipping malformed lines, and raising actionable errors when no valid QA pairs are found.
- Add `seq2seqChatbot/requirements.txt` with the runtime dependencies (`tensorflow`, `flask`, `jieba`, `zhon`).

### Testing
- Installed runtime packages with `python3 -m pip install --quiet -r seq2seqChatbot/requirements.txt` which completed successfully.
- Ran `python3 seq2seqChatbot/data_util.py` and observed the new explicit error `训练语料文件为空` when the bundled corpus is empty, confirming the validation runs (failed as expected because the corpus file is empty).
- Ran `python3 seq2seqChatbot/execute.py` and observed the new clear error message about training data absence/format instead of the previous unpacking exception, confirming improved error handling (failed as expected due to empty `seq.data`).
- Attempted to start the web server with `python3 seq2seqChatbot/app.py` and verified it now fails fast with a descriptive data-preparation error rather than an opaque crash (failed as expected until a valid corpus is provided).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c65be9820083278dd0beef305bf3fd)